### PR TITLE
Add Utilisateur DTO and related classes

### DIFF
--- a/src/main/kotlin/fr/backend/backend/controller/UtilisateurController.kt
+++ b/src/main/kotlin/fr/backend/backend/controller/UtilisateurController.kt
@@ -1,0 +1,48 @@
+package fr.backend.backend.controller
+
+import fr.backend.backend.dto.UtilisateurDto
+import fr.backend.backend.service.UtilisateurService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/utilisateurs")
+class UtilisateurController(
+    private val utilisateurService: UtilisateurService
+) {
+
+    @GetMapping
+    fun getAllUtilisateurs(): ResponseEntity<List<UtilisateurDto>> {
+        val utilisateurs = utilisateurService.getAllUtilisateurs()
+        return ResponseEntity.ok(utilisateurs)
+    }
+
+    @GetMapping("/{id}")
+    fun getUtilisateurById(@PathVariable id: UUID): ResponseEntity<UtilisateurDto> {
+        val utilisateur = utilisateurService.getUtilisateurById(id)
+        return ResponseEntity.ok(utilisateur)
+    }
+
+    @PostMapping
+    fun createUtilisateur(@RequestBody utilisateurDto: UtilisateurDto): ResponseEntity<UtilisateurDto> {
+        val newUtilisateur = utilisateurService.createUtilisateur(utilisateurDto)
+        return ResponseEntity(newUtilisateur, HttpStatus.CREATED)
+    }
+
+    @PutMapping("/{id}")
+    fun updateUtilisateur(
+        @PathVariable id: UUID,
+        @RequestBody utilisateurDto: UtilisateurDto
+    ): ResponseEntity<UtilisateurDto> {
+        val updatedUtilisateur = utilisateurService.updateUtilisateur(id, utilisateurDto)
+        return ResponseEntity.ok(updatedUtilisateur)
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteUtilisateur(@PathVariable id: UUID): ResponseEntity<Void> {
+        utilisateurService.deleteUtilisateur(id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/fr/backend/backend/dto/UtilisateurDto.kt
+++ b/src/main/kotlin/fr/backend/backend/dto/UtilisateurDto.kt
@@ -1,0 +1,10 @@
+package fr.backend.backend.dto
+
+import java.util.UUID
+
+data class UtilisateurDto(
+    val idUser: UUID? = null,
+    val email: String,
+    val password: String,
+    val entrepriseId: UUID
+)

--- a/src/main/kotlin/fr/backend/backend/mapper/UtilisateurMapper.kt
+++ b/src/main/kotlin/fr/backend/backend/mapper/UtilisateurMapper.kt
@@ -1,0 +1,27 @@
+package fr.backend.backend.mapper
+
+import fr.backend.backend.dto.UtilisateurDto
+import fr.backend.backend.model.Utilisateur
+import org.springframework.stereotype.Component
+
+@Component
+class UtilisateurMapper {
+
+    fun toDto(utilisateur: Utilisateur): UtilisateurDto {
+        return UtilisateurDto(
+            idUser = utilisateur.idUser,
+            email = utilisateur.email,
+            password = utilisateur.password,
+            entrepriseId = utilisateur.entreprise.idEntreprise!!
+        )
+    }
+
+    fun toEntity(utilisateurDto: UtilisateurDto): Utilisateur {
+        return Utilisateur(
+            idUser = utilisateurDto.idUser,
+            email = utilisateurDto.email,
+            password = utilisateurDto.password,
+            entreprise = Entreprise(idEntreprise = utilisateurDto.entrepriseId)
+        )
+    }
+}

--- a/src/main/kotlin/fr/backend/backend/repository/UtilisateurRepository.kt
+++ b/src/main/kotlin/fr/backend/backend/repository/UtilisateurRepository.kt
@@ -1,0 +1,9 @@
+package fr.backend.backend.repository
+
+import fr.backend.backend.model.Utilisateur
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface UtilisateurRepository : JpaRepository<Utilisateur, UUID>

--- a/src/main/kotlin/fr/backend/backend/service/UtilisateurService.kt
+++ b/src/main/kotlin/fr/backend/backend/service/UtilisateurService.kt
@@ -1,0 +1,47 @@
+package fr.backend.backend.service
+
+import fr.backend.backend.dto.UtilisateurDto
+import fr.backend.backend.mapper.UtilisateurMapper
+import fr.backend.backend.repository.UtilisateurRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class UtilisateurService(
+    private val utilisateurRepository: UtilisateurRepository,
+    private val utilisateurMapper: UtilisateurMapper
+) {
+
+    fun getAllUtilisateurs(): List<UtilisateurDto> {
+        val utilisateurs = utilisateurRepository.findAll()
+        return utilisateurs.map { utilisateurMapper.toDto(it) }
+    }
+
+    fun getUtilisateurById(id: UUID): UtilisateurDto {
+        val utilisateur = utilisateurRepository.findById(id).orElseThrow {
+            IllegalArgumentException("Utilisateur avec ID $id introuvable")
+        }
+        return utilisateurMapper.toDto(utilisateur)
+    }
+
+    fun createUtilisateur(utilisateurDto: UtilisateurDto): UtilisateurDto {
+        val utilisateur = utilisateurMapper.toEntity(utilisateurDto.copy(idUser = null))
+        val savedUtilisateur = utilisateurRepository.save(utilisateur)
+        return utilisateurMapper.toDto(savedUtilisateur)
+    }
+
+    fun updateUtilisateur(id: UUID, utilisateurDto: UtilisateurDto): UtilisateurDto {
+        val existingUtilisateur = utilisateurRepository.findById(id).orElseThrow {
+            IllegalArgumentException("Utilisateur avec ID $id introuvable")
+        }
+        val updatedUtilisateur = utilisateurMapper.toEntity(utilisateurDto.copy(idUser = existingUtilisateur.idUser))
+        return utilisateurMapper.toDto(utilisateurRepository.save(updatedUtilisateur))
+    }
+
+    fun deleteUtilisateur(id: UUID) {
+        if (!utilisateurRepository.existsById(id)) {
+            throw IllegalArgumentException("Utilisateur avec ID $id introuvable")
+        }
+        utilisateurRepository.deleteById(id)
+    }
+}


### PR DESCRIPTION
Add DTO, Mapper, Controller, Service, and Repository for Utilisateur entity

* **DTO**: Add `UtilisateurDto` data class with properties `idUser`, `email`, `password`, and `entrepriseId`.
* **Mapper**: Add `UtilisateurMapper` class with methods `toDto` and `toEntity` to map between `Utilisateur` entity and `UtilisateurDto`.
* **Controller**: Add `UtilisateurController` class with REST endpoints for CRUD operations on `Utilisateur` entities.
* **Service**: Add `UtilisateurService` class with methods for managing `Utilisateur` entities, including CRUD operations.
* **Repository**: Add `UtilisateurRepository` interface extending `JpaRepository` for `Utilisateur` entities.

